### PR TITLE
Support auth with username

### DIFF
--- a/src/main/scala/redis/Sentinel.scala
+++ b/src/main/scala/redis/Sentinel.scala
@@ -95,6 +95,7 @@ case class SentinelClient(
       onMessage,
       (pmessage: PMessage) => {},
       None,
+      None,
       (status: Boolean) => {}
     ).withDispatcher(redisDispatcher.name),
     name + '-' + Redis.tempName()

--- a/src/main/scala/redis/commands/Connection.scala
+++ b/src/main/scala/redis/commands/Connection.scala
@@ -8,8 +8,11 @@ import redis.protocol.Status
 import redis.api.connection._
 
 trait Connection extends Request {
-  def auth[V: ByteStringSerializer](value: V): Future[Status] =
-    send(Auth(value))
+  def auth[V: ByteStringSerializer](password: V): Future[Status] =
+    send(Auth(password))
+
+  def auth[V: ByteStringSerializer](username: V, password: V): Future[Status] =
+    send(Auth(username, Some(password)))
 
   def echo[V: ByteStringSerializer, R: ByteStringDeserializer](value: V): Future[Option[R]] =
     send(Echo(value))

--- a/src/test/scala/redis/RedisPubSubSpec.scala
+++ b/src/test/scala/redis/RedisPubSubSpec.scala
@@ -112,7 +112,7 @@ class RedisPubSubSpec extends RedisDockerServer {
 }
 
 class SubscriberActor(address: InetSocketAddress, channels: Seq[String], patterns: Seq[String], probeMock: ActorRef)
-    extends RedisSubscriberActor(address, channels, patterns, None, (b: Boolean) => ()) {
+    extends RedisSubscriberActor(address, channels, patterns, None, None, (b: Boolean) => ()) {
 
   override def onMessage(m: Message) = {
     probeMock ! m

--- a/src/test/scala/redis/actors/RedisSubscriberActorSpec.scala
+++ b/src/test/scala/redis/actors/RedisSubscriberActorSpec.scala
@@ -68,7 +68,7 @@ class RedisSubscriberActorSpec extends TestKit(ActorSystem()) with Specification
 }
 
 class SubscriberActor(address: InetSocketAddress, channels: Seq[String], patterns: Seq[String], probeMock: ActorRef)
-    extends RedisSubscriberActor(address, channels, patterns, None, (status: Boolean) => { () }) {
+    extends RedisSubscriberActor(address, channels, patterns, None, None, (status: Boolean) => { () }) {
 
   override val tcp = probeMock
 


### PR DESCRIPTION
- fix #61 

Since Redis 6, AUTH command is enhanced from `AUTH password` to `AUTH [username] password` ( https://redis.io/commands/auth/ ). This enhancement is already employed on some cloud services.

This patch add support of an username parameter for AUTH command.

In some API, a parameter order is changed (`username` is added just before `password`), so user programs may need to follow the change. (I don't want to add `username` parameter to the end of parameters, so. I wonder whether this change is acceptable. If not I'm ok to move the new parameter as an optional parameter to the last of parameters.)
